### PR TITLE
Gulp 4 Compat.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/akim-mcmath/gulp-transform#readme",
   "peerDependencies": {
-    "gulp": ">=3.0.0"
+    "gulp": "3 - 4"
   },
   "dependencies": {
     "es6-promise": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/akim-mcmath/gulp-transform#readme",
   "peerDependencies": {
-    "gulp": "3.x"
+    "gulp": ">=3.0.0"
   },
   "dependencies": {
     "es6-promise": "^4.0.5",


### PR DESCRIPTION
Updating `peerDependencies` to allow for anything `>=3.0.0`, because I keep getting this NPM warning when using Gulp v4.

```
npm WARN gulp-transform@1.1.0 requires a peer of gulp@3.x but none was installed.
```