### PR TITLE
Fix: declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ files.
 
 Install via [npm][npm]:
 
-```
+```sh
 npm install --save-dev gulp gulp-transform
 ```
 
@@ -232,9 +232,9 @@ returned.
 
 ## TypeScript
 
-Type declarations are included in the package.
+[TypeScript][typescript] declarations are included in the package.
 
-```
+```sh
 npm i -D typescript ts-node gulp @types/gulp gulp-transform
 ```
 
@@ -270,3 +270,4 @@ Copyright &copy; 2016&ndash;2017 Akim McMath. Licensed under the [MIT License][l
 [encoding]: https://nodejs.org/dist/latest/docs/api/buffer.html#buffer_buffers_and_character_encodings
 [nodeBuffer]: https://nodejs.org/dist/latest-v8.x/docs/api/buffer.html
 [promise]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[typescript]: https://www.typescriptlang.org/

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -11,6 +11,8 @@ interface Options {
 /**
  * A normalized configuration object based on arguments passed to
  * the plugin.
+ *
+ * @internal
  */
 export class Config {
 

--- a/src/ContentTransformer.ts
+++ b/src/ContentTransformer.ts
@@ -5,6 +5,8 @@ import { PLUGIN_NAME, TransformFunction, isString } from "./common";
 /**
  * Creates a function for applying a user-defined transformation to
  * file contents.
+ *
+ * @internal
  */
 export class ContentTransformer {
 

--- a/src/FileContentStream.ts
+++ b/src/FileContentStream.ts
@@ -4,6 +4,8 @@ import { PLUGIN_NAME, NodeCallback, StreamFile, TransformFunction } from "./comm
 
 /**
  * The transformed contents of a File object in streaming mode.
+ *
+ * @internal
  */
 export class FileContentStream extends Transform {
 

--- a/src/GulpTransformStream.ts
+++ b/src/GulpTransformStream.ts
@@ -5,6 +5,8 @@ import { PLUGIN_NAME, TransformFunction, BufferFile, StreamFile, NodeCallback } 
 
 /**
  * A stream of File objects returned by the plugin.
+ *
+ * @internal
  */
 export class GulpTransformStream extends Transform {
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,6 +3,8 @@ import { File } from "gulp-util";
 /**
  * Accepts the contents of a File object as a Buffer, applies a
  * transformation, and returns a Promise with the result.
+ *
+ * @internal
  */
 export interface TransformFunction {
     (contents: Buffer, file: File): Promise<Buffer>;
@@ -10,6 +12,8 @@ export interface TransformFunction {
 
 /**
  * A Vinyl File object in buffer mode.
+ *
+ * @internal
  */
 export interface BufferFile extends File {
     contents: Buffer;
@@ -17,6 +21,8 @@ export interface BufferFile extends File {
 
 /**
  * A Vinyl File object in streaming mode.
+ *
+ * @internal
  */
 export interface StreamFile extends File {
     contents: NodeJS.ReadableStream;
@@ -24,6 +30,8 @@ export interface StreamFile extends File {
 
 /**
  * A Node.js callback.
+ *
+ * @internal
  */
 export interface NodeCallback<T> {
     (error: null, value: T): void;
@@ -32,11 +40,15 @@ export interface NodeCallback<T> {
 
 /**
  * The name to display when a PluginError is thrown or emitted.
+ *
+ * @internal
  */
 export const PLUGIN_NAME = "gulp-transform";
 
 /**
  * Tests whether a value is a function.
+ *
+ * @internal
  */
 export function isFunction(value: any): value is Function {
     return typeof value === "function";
@@ -44,6 +56,8 @@ export function isFunction(value: any): value is Function {
 
 /**
  * Tests whether a value is either null or undefined.
+ *
+ * @internal
  */
 export function isNil(value: any): value is null | undefined {
     return value == null;
@@ -51,6 +65,8 @@ export function isNil(value: any): value is null | undefined {
 
 /**
  * Tests whether a value is an object that is not a function.
+ *
+ * @internal
  */
 export function isObjectLike(value: any): value is object {
     return typeof value === "object" && !!value;
@@ -58,6 +74,8 @@ export function isObjectLike(value: any): value is object {
 
 /**
  * Tests whether a value is a string primitive.
+ *
+ * @internal
  */
 export function isString(value: any): value is string {
     return typeof value === "string";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { File } from "gulp-util";
 import { Config } from "./Config";
 import { ContentTransformer } from "./ContentTransformer";
 import { GulpTransformStream } from "./GulpTransformStream";


### PR DESCRIPTION
  - Fixes type declarations by (1) adding the `@internal` tag to exports
    used internally and (2) importing `File` from `gulp-util` in
    index.ts
  - Makes minor changes to docs in README.md